### PR TITLE
MX Records with priority level = 0 crashes route53.php (line 221) (fixes #2)

### DIFF
--- a/plib/scripts/route53.php
+++ b/plib/scripts/route53.php
@@ -191,7 +191,15 @@ foreach ($data as $record) {
                         ),
                     );
                 }
-                $opt = $rr->opt ? "{$rr->opt} " : '';
+
+                if ('MX' == $rr->type && 0 == $rr->opt) {
+                    $opt = "1 ";
+                } elseif ($rr->opt) {
+                    $opt = "{$rr->opt} ";
+                } else {
+                    $opt = '';
+                }
+
                 if ('TXT' == $rr->type) {
                     /**
                      * AWS Route 53 requires quotation of the TXT Resource Record value


### PR DESCRIPTION
Always pass MX priority: workaround zero cast to empty string (fixes #2)
