### PR TITLE
[Feature] Adds "Managed Domains" to the Extension

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -1,34 +1,33 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
     "content-hash": "edc82659b02fbbe7fd5236c50210b0d6",
     "packages": [
         {
             "name": "aws/aws-sdk-php",
-            "version": "3.52.20",
+            "version": "3.137.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/aws/aws-sdk-php.git",
-                "reference": "299ac47ff5171d6a25f788dc333c0a3c8db40f69"
+                "reference": "0bed146e6336ca1260e937fce2f4931681ceb3ce"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/299ac47ff5171d6a25f788dc333c0a3c8db40f69",
-                "reference": "299ac47ff5171d6a25f788dc333c0a3c8db40f69",
+                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/0bed146e6336ca1260e937fce2f4931681ceb3ce",
+                "reference": "0bed146e6336ca1260e937fce2f4931681ceb3ce",
                 "shasum": ""
             },
             "require": {
                 "ext-json": "*",
                 "ext-pcre": "*",
                 "ext-simplexml": "*",
-                "ext-spl": "*",
-                "guzzlehttp/guzzle": "^5.3.1|^6.2.1",
-                "guzzlehttp/promises": "~1.0",
+                "guzzlehttp/guzzle": "^5.3.3|^6.2.1|^7.0",
+                "guzzlehttp/promises": "^1.0",
                 "guzzlehttp/psr7": "^1.4.1",
-                "mtdowling/jmespath.php": "~2.2",
+                "mtdowling/jmespath.php": "^2.5",
                 "php": ">=5.5"
             },
             "require-dev": {
@@ -38,15 +37,20 @@
                 "doctrine/cache": "~1.4",
                 "ext-dom": "*",
                 "ext-openssl": "*",
+                "ext-pcntl": "*",
+                "ext-sockets": "*",
                 "nette/neon": "^2.3",
                 "phpunit/phpunit": "^4.8.35|^5.4.3",
-                "psr/cache": "^1.0"
+                "psr/cache": "^1.0",
+                "psr/simple-cache": "^1.0",
+                "sebastian/comparator": "^1.2.3"
             },
             "suggest": {
                 "aws/aws-php-sns-message-validator": "To validate incoming SNS notifications",
                 "doctrine/cache": "To use the DoctrineCacheAdapter",
                 "ext-curl": "To send requests using cURL",
-                "ext-openssl": "Allows working with CloudFront private distributions and verifying received SNS messages"
+                "ext-openssl": "Allows working with CloudFront private distributions and verifying received SNS messages",
+                "ext-sockets": "To use client-side monitoring"
             },
             "type": "library",
             "extra": {
@@ -84,31 +88,33 @@
                 "s3",
                 "sdk"
             ],
-            "time": "2018-03-01T20:18:42+00:00"
+            "time": "2020-05-06T18:19:09+00:00"
         },
         {
             "name": "guzzlehttp/guzzle",
-            "version": "6.3.0",
+            "version": "6.5.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/guzzle.git",
-                "reference": "f4db5a78a5ea468d4831de7f0bf9d9415e348699"
+                "reference": "aab4ebd862aa7d04f01a4b51849d657db56d882e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/f4db5a78a5ea468d4831de7f0bf9d9415e348699",
-                "reference": "f4db5a78a5ea468d4831de7f0bf9d9415e348699",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/aab4ebd862aa7d04f01a4b51849d657db56d882e",
+                "reference": "aab4ebd862aa7d04f01a4b51849d657db56d882e",
                 "shasum": ""
             },
             "require": {
+                "ext-json": "*",
                 "guzzlehttp/promises": "^1.0",
-                "guzzlehttp/psr7": "^1.4",
-                "php": ">=5.5"
+                "guzzlehttp/psr7": "^1.6.1",
+                "php": ">=5.5",
+                "symfony/polyfill-intl-idn": "^1.11"
             },
             "require-dev": {
                 "ext-curl": "*",
-                "phpunit/phpunit": "^4.0 || ^5.0",
-                "psr/log": "^1.0"
+                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.4 || ^7.0",
+                "psr/log": "^1.1"
             },
             "suggest": {
                 "psr/log": "Required for using the Log middleware"
@@ -116,16 +122,16 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "6.2-dev"
+                    "dev-master": "6.5-dev"
                 }
             },
             "autoload": {
-                "files": [
-                    "src/functions_include.php"
-                ],
                 "psr-4": {
                     "GuzzleHttp\\": "src/"
-                }
+                },
+                "files": [
+                    "src/functions_include.php"
+                ]
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -149,7 +155,7 @@
                 "rest",
                 "web service"
             ],
-            "time": "2017-06-22T18:50:49+00:00"
+            "time": "2020-04-18T10:38:46+00:00"
         },
         {
             "name": "guzzlehttp/promises",
@@ -204,32 +210,37 @@
         },
         {
             "name": "guzzlehttp/psr7",
-            "version": "1.4.2",
+            "version": "1.6.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/psr7.git",
-                "reference": "f5b8a8512e2b58b0071a7280e39f14f72e05d87c"
+                "reference": "239400de7a173fe9901b9ac7c06497751f00727a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/psr7/zipball/f5b8a8512e2b58b0071a7280e39f14f72e05d87c",
-                "reference": "f5b8a8512e2b58b0071a7280e39f14f72e05d87c",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/239400de7a173fe9901b9ac7c06497751f00727a",
+                "reference": "239400de7a173fe9901b9ac7c06497751f00727a",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.4.0",
-                "psr/http-message": "~1.0"
+                "psr/http-message": "~1.0",
+                "ralouphie/getallheaders": "^2.0.5 || ^3.0.0"
             },
             "provide": {
                 "psr/http-message-implementation": "1.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.0"
+                "ext-zlib": "*",
+                "phpunit/phpunit": "~4.8.36 || ^5.7.27 || ^6.5.8"
+            },
+            "suggest": {
+                "zendframework/zend-httphandlerrunner": "Emit PSR-7 responses"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.4-dev"
+                    "dev-master": "1.6-dev"
                 }
             },
             "autoload": {
@@ -259,33 +270,36 @@
             "keywords": [
                 "http",
                 "message",
+                "psr-7",
                 "request",
                 "response",
                 "stream",
                 "uri",
                 "url"
             ],
-            "time": "2017-03-20T17:10:46+00:00"
+            "time": "2019-07-01T23:21:34+00:00"
         },
         {
             "name": "mtdowling/jmespath.php",
-            "version": "2.4.0",
+            "version": "2.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/jmespath/jmespath.php.git",
-                "reference": "adcc9531682cf87dfda21e1fd5d0e7a41d292fac"
+                "reference": "52168cb9472de06979613d365c7f1ab8798be895"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/jmespath/jmespath.php/zipball/adcc9531682cf87dfda21e1fd5d0e7a41d292fac",
-                "reference": "adcc9531682cf87dfda21e1fd5d0e7a41d292fac",
+                "url": "https://api.github.com/repos/jmespath/jmespath.php/zipball/52168cb9472de06979613d365c7f1ab8798be895",
+                "reference": "52168cb9472de06979613d365c7f1ab8798be895",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.4.0"
+                "php": ">=5.4.0",
+                "symfony/polyfill-mbstring": "^1.4"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.0"
+                "composer/xdebug-handler": "^1.2",
+                "phpunit/phpunit": "^4.8.36|^7.5.15"
             },
             "bin": [
                 "bin/jp.php"
@@ -293,7 +307,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0-dev"
+                    "dev-master": "2.5-dev"
                 }
             },
             "autoload": {
@@ -320,7 +334,7 @@
                 "json",
                 "jsonpath"
             ],
-            "time": "2016-12-03T22:08:25+00:00"
+            "time": "2019-12-30T18:03:34+00:00"
         },
         {
             "name": "plesk/amazon-iam",
@@ -401,6 +415,264 @@
                 "response"
             ],
             "time": "2016-08-06T14:39:51+00:00"
+        },
+        {
+            "name": "ralouphie/getallheaders",
+            "version": "3.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ralouphie/getallheaders.git",
+                "reference": "120b605dfeb996808c31b6477290a714d356e822"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ralouphie/getallheaders/zipball/120b605dfeb996808c31b6477290a714d356e822",
+                "reference": "120b605dfeb996808c31b6477290a714d356e822",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.6"
+            },
+            "require-dev": {
+                "php-coveralls/php-coveralls": "^2.1",
+                "phpunit/phpunit": "^5 || ^6.5"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/getallheaders.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ralph Khattar",
+                    "email": "ralph.khattar@gmail.com"
+                }
+            ],
+            "description": "A polyfill for getallheaders.",
+            "time": "2019-03-08T08:55:37+00:00"
+        },
+        {
+            "name": "symfony/polyfill-intl-idn",
+            "version": "v1.15.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-intl-idn.git",
+                "reference": "47bd6aa45beb1cd7c6a16b7d1810133b728bdfcf"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-idn/zipball/47bd6aa45beb1cd7c6a16b7d1810133b728bdfcf",
+                "reference": "47bd6aa45beb1cd7c6a16b7d1810133b728bdfcf",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3",
+                "symfony/polyfill-mbstring": "^1.3",
+                "symfony/polyfill-php72": "^1.10"
+            },
+            "suggest": {
+                "ext-intl": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.15-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Intl\\Idn\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Laurent Bassin",
+                    "email": "laurent@bassin.info"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for intl's idn_to_ascii and idn_to_utf8 functions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "idn",
+                "intl",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-03-09T19:04:49+00:00"
+        },
+        {
+            "name": "symfony/polyfill-mbstring",
+            "version": "v1.15.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-mbstring.git",
+                "reference": "81ffd3a9c6d707be22e3012b827de1c9775fc5ac"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/81ffd3a9c6d707be22e3012b827de1c9775fc5ac",
+                "reference": "81ffd3a9c6d707be22e3012b827de1c9775fc5ac",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "suggest": {
+                "ext-mbstring": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.15-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Mbstring\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for the Mbstring extension",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "mbstring",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-03-09T19:04:49+00:00"
+        },
+        {
+            "name": "symfony/polyfill-php72",
+            "version": "v1.15.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-php72.git",
+                "reference": "37b0976c78b94856543260ce09b460a7bc852747"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-php72/zipball/37b0976c78b94856543260ce09b460a7bc852747",
+                "reference": "37b0976c78b94856543260ce09b460a7bc852747",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.15-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php72\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill backporting some PHP 7.2+ features to lower PHP versions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-02-27T09:26:54+00:00"
         }
     ],
     "packages-dev": [],
@@ -412,5 +684,6 @@
     "platform": {
         "php": "^5.6 || ^7.0"
     },
-    "platform-dev": []
+    "platform-dev": [],
+    "plugin-api-version": "1.1.0"
 }

--- a/src/plib/controllers/IndexController.php
+++ b/src/plib/controllers/IndexController.php
@@ -93,7 +93,7 @@ class IndexController extends pm_Controller_Action
             throw new pm_Exception('Permission denied');
         }
 
-        Modules_Route53_Settings::removeManagedDomainById((int)$this->_getParam('id'));
+        Modules_Route53_Settings::removeManagedDomainById($this->_getParam('id'));
 
         $this->_redirect('index/managed-domain');
     }

--- a/src/plib/controllers/IndexController.php
+++ b/src/plib/controllers/IndexController.php
@@ -52,11 +52,50 @@ class IndexController extends pm_Controller_Action
                 'action' => 'delegation-set',
             ];
             $tabs[] = [
+                'title' => $this->lmsg('managedDomainsTitle'),
+                'action' => 'managed-domain'
+            ];
+            $tabs[] = [
                 'title' => $this->lmsg('toolsTitle'),
                 'action' => 'tools',
             ];
         }
         return $tabs;
+    }
+
+    public function managedDomainAction()
+    {
+        $this->view->list = new Modules_Route53_List_ManagedDomains($this->view, $this->getRequest());
+        $this->view->tabs = $this->_getTabs();
+    }
+
+    public function createManagedDomainAction()
+    {
+        $form = new Modules_Route53_Form_ManagedDomains();
+
+        if ($this->getRequest()->isPost() && $form->isValid($this->getRequest()->getPost())) {
+            try {
+                $form->process();
+                $this->_status->addMessage('info', $this->lmsg('managedDomainCreated'));
+            } catch (Exception $e) {
+                $this->_status->addMessage('error', $e->getMessage());
+            }
+            $this->_helper->json(array('redirect' => $this->_helper->url('managed-domain')));
+        }
+
+        $this->view->pageTitle = $this->lmsg('createManagedDomainButton');
+        $this->view->form = $form;
+    }
+
+    public function deleteManagedDomainAction()
+    {
+        if (!$this->getRequest()->isPost()) {
+            throw new pm_Exception('Permission denied');
+        }
+
+        Modules_Route53_Settings::removeManagedDomainById((int)$this->_getParam('id'));
+
+        $this->_redirect('index/managed-domain');
     }
 
     public function delegationSetAction()

--- a/src/plib/controllers/IndexController.php
+++ b/src/plib/controllers/IndexController.php
@@ -260,7 +260,7 @@ class IndexController extends pm_Controller_Action
         }
 
         $domainAliases = $this->getDomainAliasListApi();
-        $domains = array_merge($domains, $domainAliases, Modules_Route53_Settings::getManagedDomains());
+        $domains = array_merge($domains, $domainAliases, Modules_Route53_Settings::getManagedDomainNames());
 
         $client = Modules_Route53_Client::factory();
         $hostedZones = $client->getZones();
@@ -275,9 +275,9 @@ class IndexController extends pm_Controller_Action
             $api = pm_ApiRpc::getService();
             $request = '<packet><dns><get_rec><filter/></get_rec></dns></packet>';
             $response = $api->call($request);
-            $responseRecords = json_decode(json_encode($response->{'dns'}->get_rec));
+            $responseRecords = json_decode(json_encode($response->{'dns'}->get_rec), true);
 
-            foreach ($responseRecords as $responseRecord) {
+            foreach ($responseRecords['result'] as $responseRecord) {
                 $name = $responseRecord['data']['host'];
                 $type = $responseRecord['data']['type'];
 

--- a/src/plib/controllers/IndexController.php
+++ b/src/plib/controllers/IndexController.php
@@ -266,7 +266,7 @@ class IndexController extends pm_Controller_Action
         $hostedZones = $client->getZones();
 
         foreach ($hostedZones as $zoneDomain => $zoneId) {
-            if (!in_array($zoneDomain, $domains)) {
+            if (!in_array($zoneDomain, $domains) || Modules_Route53_Settings::isManagedDomain($zoneDomain)) {
                 continue;
             }
 
@@ -278,10 +278,6 @@ class IndexController extends pm_Controller_Action
                         'Changes' => $zoneChanges,
                     ],
                 ]);
-            }
-
-            if (Modules_Route53_Settings::isManagedDomain($zoneDomain)) {
-                continue;
             }
 
             $client->deleteHostedZone([

--- a/src/plib/library/Client.php
+++ b/src/plib/library/Client.php
@@ -203,8 +203,7 @@ class Modules_Route53_Client
 
         foreach ($recordSets as $recordSet) {
             $change = "DELETE ${recordSet['Name']} ${recordSet['Type']}";
-            pm_Log::err($change);
-            pm_Log::err(json_encode($allowedChanges));
+
             if (
                 ($allowedChanges && !in_array($change, $allowedChanges))
                 || !in_array($recordSet['Type'], $this->getConfig()['supportedTypes'])

--- a/src/plib/library/Client.php
+++ b/src/plib/library/Client.php
@@ -196,16 +196,18 @@ class Modules_Route53_Client
         }
     }
 
-    public function getHostedZoneRecordsToDelete($zoneId, $allowedChanges)
+    public function getHostedZoneRecordsToDelete($zoneId, $allowedChanges = [])
     {
         $changes = [];
         $recordSets = $this->getHostedZoneRecordSets($zoneId);
 
         foreach ($recordSets as $recordSet) {
-            $change = "DELETE ${$recordSet['name']} ${$recordSet['type']}";
+            $change = "DELETE ${recordSet['Name']} ${recordSet['Type']}";
+            pm_Log::err($change);
+            pm_Log::err(json_encode($allowedChanges));
             if (
-                !in_array($recordSet['Type'], $this->getConfig()['supportedTypes'])
-                && !in_array($change, $allowedChanges)
+                ($allowedChanges && !in_array($change, $allowedChanges))
+                || !in_array($recordSet['Type'], $this->getConfig()['supportedTypes'])
             ) {
                 continue;
             }

--- a/src/plib/library/Client.php
+++ b/src/plib/library/Client.php
@@ -249,7 +249,7 @@ class Modules_Route53_Client
                 'secret' => pm_Settings::get('secret'),
             ],
             'version' => '2013-04-01',
-            'region' => 'us-east-1',
+            'region' => pm_Settings::get('region'),
         ], $config);
 
         if (pm_ProductInfo::isWindows()) {

--- a/src/plib/library/Client.php
+++ b/src/plib/library/Client.php
@@ -196,18 +196,21 @@ class Modules_Route53_Client
         }
     }
 
-    public function getHostedZoneRecordsToDelete($zoneId)
+    public function getHostedZoneRecordsToDelete($zoneId, $allowedChanges)
     {
         $changes = [];
         $recordSets = $this->getHostedZoneRecordSets($zoneId);
 
         foreach ($recordSets as $recordSet) {
-
-            if (!in_array($recordSet['Type'], $this->getConfig()['supportedTypes'])) {
+            $change = "DELETE ${$recordSet['name']} ${$recordSet['type']}";
+            if (
+                !in_array($recordSet['Type'], $this->getConfig()['supportedTypes'])
+                && !in_array($change, $allowedChanges)
+            ) {
                 continue;
             }
 
-            $changes[] = [
+            $changes[$change] = [
                 'Action' => 'DELETE',
                 'ResourceRecordSet' => $recordSet,
             ];

--- a/src/plib/library/EventListener.php
+++ b/src/plib/library/EventListener.php
@@ -89,7 +89,7 @@ APICALL;
                 'secret' => pm_Settings::get('secret'),
             ],
             'version' => '2010-12-01',
-            'region' => 'eu-central-1',
+            'region' => pm_Settings::get('region'),
         ]);
     }
 }

--- a/src/plib/library/EventListener.php
+++ b/src/plib/library/EventListener.php
@@ -71,6 +71,7 @@ APICALL;
 </dns>
 </packet>
 APICALL;
+                pm_ApiRpc::getService('1.6.8.0')->call($request);
             }
         }
     }

--- a/src/plib/library/EventListener.php
+++ b/src/plib/library/EventListener.php
@@ -1,0 +1,97 @@
+<?php
+
+/**
+ * Event listener for route53 integration.
+ *
+ * Handles site_create and site_remove events to add and remove Amazon SES verification tokens.
+ * Required permissions: ses:VerifyDomainIdentity, ses:DeleteIdentity
+ */
+class Modules_Route53_EventListener implements EventListener
+{
+    public function filterActions()
+    {
+        return [
+            'site_create',
+            'site_delete'
+        ];
+    }
+
+    public function handleEvent($objectType, $objectId, $action, $oldValues, $newValues)
+    {
+        switch ($action) {
+            case 'site_create' :
+                $this->addAmazonSesVerificationEntry($newValues['Domain Name'], (int)$objectId);
+                break;
+            case 'site_delete':
+                $this->removeAmazonSesVerificationEntry($oldValues['Domain Name']);
+                break;
+        }
+    }
+
+    /**
+     * Get verification token from AWS SES API and set it as TXT entry for the new domain
+     *
+     * @param string $domain
+     * @param int $siteId
+     */
+    private function addAmazonSesVerificationEntry(string $domain, int $siteId)
+    {
+        $request = <<<APICALL
+<packet>
+<dns>
+ <get_rec>
+  <filter>
+    <site-id>${siteId}</site-id>
+  </filter>
+ </get_rec>
+</dns>
+</packet>
+APICALL;
+        $response = pm_ApiRpc::getService('1.6.8.0')->call($request);
+        $oldVerificationToken = '';
+        foreach($response->dns->get_rec as $record) {
+            if (strpos('_amazonses', $record->data->host) !== false) {
+                $oldVerificationToken = $record->data->value;
+                break;
+            }
+        }
+        $result = $this->getSesClient()->verifyDomainIdentity(['Domain' => $domain]);
+        if ($result->hasKey('VerificationToken')) {
+            $verificationToken = $result->get('VerificationToken');
+            if ($verificationToken !== $oldVerificationToken) {
+                $request = <<<APICALL
+<packet>
+<dns>
+   <add_rec>
+      <site-id>${siteId}</site-id>
+      <type>TXT</type>
+      <host>_amazonses</host>
+      <value>${verificationToken}</value>
+   </add_rec>
+</dns>
+</packet>
+APICALL;
+            }
+        }
+    }
+
+    private function removeAmazonSesVerificationEntry(string $domain)
+    {
+        $this->getSesClient()->deleteIdentity(['Identity' => $domain]);
+    }
+
+    private function getSesClient()
+    {
+        return new \Aws\Ses\SesClient([
+            'exception_class' => 'Modules_Route53_Exception',
+            'credentials' => [
+                'key' => pm_Settings::get('key'),
+                'secret' => pm_Settings::get('secret'),
+            ],
+            'version' => '2010-12-01',
+            'region' => 'eu-central-1',
+        ]);
+    }
+}
+
+return new Modules_Route53_EventListener();

--- a/src/plib/library/Form/ManagedDomains.php
+++ b/src/plib/library/Form/ManagedDomains.php
@@ -24,8 +24,8 @@ class Modules_Route53_Form_ManagedDomains extends pm_Form_Simple
             'label' => pm_Locale::lmsg('managedDomainModeLabel'),
             'required' => true,
             'multiOptions' => [
-                Modules_Route53_Settings::MANAGE_DOMAIN_MODE_A_RECORD_WITH_SERVER_ADDRESS
-                => $this->lmsg('managedDomainsMode' . Modules_Route53_Settings::MANAGE_DOMAIN_MODE_A_RECORD_WITH_SERVER_ADDRESS),
+                Modules_Route53_Settings::MANAGED_DOMAIN_WITHOUT_NS
+                => $this->lmsg('managedDomainsMode' . Modules_Route53_Settings::MANAGED_DOMAIN_WITHOUT_NS),
             ],
             'validators' => [
                 ['NotEmpty', true],

--- a/src/plib/library/Form/ManagedDomains.php
+++ b/src/plib/library/Form/ManagedDomains.php
@@ -1,0 +1,32 @@
+<?php
+// Copyright 1999-2018. Plesk International GmbH.
+class Modules_Route53_Form_ManagedDomains extends pm_Form_Simple
+{
+    public function init()
+    {
+        parent::init();
+
+        $this->addElement('description', 'description', [
+            'description' => $this->lmsg('createManagedDomainHint'),
+            'escape' => false,
+        ]);
+
+        $this->addElement('text', 'managedDomain', [
+            'label' => pm_Locale::lmsg('managedDomainLabel'),
+            'class' => 'f-large-size',
+            'required' => true,
+            'validators' => [
+                ['NotEmpty', true],
+            ],
+        ]);
+
+        $this->addControlButtons([
+            'cancelLink' => pm_Context::getBaseUrl(),
+        ]);
+    }
+
+    public function process()
+    {
+        Modules_Route53_Settings::addManagedDomain($this->getValue('managedDomain'));
+    }
+}

--- a/src/plib/library/Form/ManagedDomains.php
+++ b/src/plib/library/Form/ManagedDomains.php
@@ -20,6 +20,18 @@ class Modules_Route53_Form_ManagedDomains extends pm_Form_Simple
             ],
         ]);
 
+        $this->addElement('radio', 'mode', [
+            'label' => pm_Locale::lmsg('managedDomainModeLabel'),
+            'required' => true,
+            'multiOptions' => [
+                Modules_Route53_Settings::MANAGE_DOMAIN_MODE_A_RECORD_WITH_SERVER_ADDRESS
+                => $this->lmsg('managedDomainsMode' . Modules_Route53_Settings::MANAGE_DOMAIN_MODE_A_RECORD_WITH_SERVER_ADDRESS),
+            ],
+            'validators' => [
+                ['NotEmpty', true],
+            ],
+        ]);
+
         $this->addControlButtons([
             'cancelLink' => pm_Context::getBaseUrl(),
         ]);
@@ -27,6 +39,6 @@ class Modules_Route53_Form_ManagedDomains extends pm_Form_Simple
 
     public function process()
     {
-        Modules_Route53_Settings::addManagedDomain($this->getValue('managedDomain'));
+        Modules_Route53_Settings::addManagedDomain($this->getValue('managedDomain'), $this->getValue('mode'));
     }
 }

--- a/src/plib/library/Form/Settings.php
+++ b/src/plib/library/Form/Settings.php
@@ -72,7 +72,7 @@ class Modules_Route53_Form_Settings extends pm_Form_Simple
         ));
         $this->addElement('text', 'region', array(
             'label' => pm_Locale::lmsg('regionLabel'),
-            'value' => pm_Settings::get('region') ?? 'us-east-1',
+            'value' => pm_Settings::get('region'),
             'class' => 'f-large-size',
             'required' => true,
             'validators' => array(

--- a/src/plib/library/List/ManagedDomains.php
+++ b/src/plib/library/List/ManagedDomains.php
@@ -11,6 +11,10 @@ class Modules_Route53_List_ManagedDomains extends pm_View_List_Simple
                 'title' => $this->lmsg('managedDomainColumn'),
                 'noEscape' => true,
             ],
+            'mode' => [
+                'title' => $this->lmsg('modeColumn'),
+                'noEscape' => true,
+            ],
             'actions' => [
                 'title' => $this->lmsg('actionsColumn'),
                 'noEscape' => true,
@@ -36,8 +40,10 @@ class Modules_Route53_List_ManagedDomains extends pm_View_List_Simple
         $data = [];
 
         foreach ($managedDomains as $key => $managedDomain) {
+            $key = urlencode($key);
             $data[] = [
-                'managedDomain' => $managedDomain,
+                'managedDomain' => $managedDomain['name'],
+                'mode' => $this->lmsg('managedDomainsMode' . $managedDomain['mode']),
                 'actions' =>
                     "<a class='s-btn sb-delete' data-method='post'"
                     . " href='{$view->url(['action' => 'delete-managed-domain'])}?id=$key'>"

--- a/src/plib/library/List/ManagedDomains.php
+++ b/src/plib/library/List/ManagedDomains.php
@@ -1,0 +1,52 @@
+<?php
+// Copyright 1999-2018. Plesk International GmbH.
+class Modules_Route53_List_ManagedDomains extends pm_View_List_Simple
+{
+    public function __construct($view, $request, $options = [])
+    {
+        parent::__construct($view, $request, $options);
+
+        $this->setColumns([
+            'managedDomain' => [
+                'title' => $this->lmsg('managedDomainColumn'),
+                'noEscape' => true,
+            ],
+            'actions' => [
+                'title' => $this->lmsg('actionsColumn'),
+                'noEscape' => true,
+            ],
+        ]);
+
+        $this->setData($this->_getRecords($view));
+        $this->setDataUrl($view->url(['action' => 'managed-domain-data']));
+
+        $this->setTools([
+            [
+                'title' => $this->lmsg('createManagedDomainButton'),
+                'description' => $this->lmsg('createManagedDomainHint'),
+                'action' => 'create-managed-domain',
+                'class' => 'sb-item-add',
+            ],
+        ]);
+    }
+
+    private function _getRecords($view)
+    {
+        $managedDomains = Modules_Route53_Settings::getManagedDomains();
+        $data = [];
+
+        foreach ($managedDomains as $key => $managedDomain) {
+            $data[] = [
+                'managedDomain' => $managedDomain,
+                'actions' =>
+                    "<a class='s-btn sb-delete' data-method='post'"
+                    . " href='{$view->url(['action' => 'delete-managed-domain'])}?id=$key'>"
+                    . "<span>"
+                    . $this->lmsg('deleteManagedDomainButton')
+                    . "</span>"
+                    . "</a>"
+            ];
+        }
+        return $data;
+    }
+}

--- a/src/plib/library/ServerInfoUtility.php
+++ b/src/plib/library/ServerInfoUtility.php
@@ -1,0 +1,24 @@
+<?php
+// Copyright 1999-2018. Plesk International GmbH.
+
+class Modules_Route53_ServerInfoUtility
+{
+    public static function getIpAddresses()
+    {
+        $addresses = [];
+        $ipRequest = '<ip><get></get></ip>';
+
+        $api = pm_ApiRpc::getService();
+        $ipResponse = $api->call($ipRequest);
+        $addressInfos = $ipResponse->xpath('/packet/ip/get/result/addresses/ip_info');
+
+        foreach ($addressInfos as $addressInfo) {
+            $address = (string)$addressInfo->public_ip_address;
+            if ($address) {
+                $addresses[$address] = strpos($address, '.') ? 'A' : 'AAAA';
+            }
+        }
+
+        return $addresses;
+    }
+}

--- a/src/plib/library/Settings.php
+++ b/src/plib/library/Settings.php
@@ -26,6 +26,19 @@ class Modules_Route53_Settings
         return $managedDomains;
     }
 
+    public static function getManagedDomainNames()
+    {
+        $names = [];
+
+        $managedDomains = self::getManagedDomains();
+
+        foreach ($managedDomains as $managedDomain) {
+            $names[] = $managedDomain['name'];
+        }
+
+        return $names;
+    }
+
     /**
      * Sets managedDomains in Plesk settings
      *

--- a/src/plib/library/Settings.php
+++ b/src/plib/library/Settings.php
@@ -42,6 +42,8 @@ class Modules_Route53_Settings
     public static function addManagedDomain($managedDomain)
     {
         $managedDomains = self::getManagedDomains();
+        $managedDomain = strtolower($managedDomain);
+        $managedDomain = substr($managedDomain, -1) === '.' ? $managedDomain : $managedDomain . '.';
         $managedDomains[] = $managedDomain;
         self::setManagedDomains($managedDomains);
     }
@@ -56,5 +58,36 @@ class Modules_Route53_Settings
         $managedDomains = self::getManagedDomains();
         unset($managedDomains[$id]);
         self::setManagedDomains($managedDomains);
+    }
+
+    /**
+     * Checks if subdomain is of any managedDomain
+     *
+     * @param string $subdomain
+     * @return bool
+     */
+    public static function getManagedDomainOfSubdomain($subdomain)
+    {
+        // Domains end with an additional . so a subdomain has do contain at least 3 of them: sub.domain.tld.
+        if (substr_count($subdomain, '.') < 3) {
+            return '';
+        }
+
+        $managedDomains = self::getManagedDomains();
+        $parts = array_reverse(array_filter(explode('.', $subdomain)));
+        $domain = $parts[1] . '.' . $parts[0] . '.';
+
+        return in_array($domain, $managedDomains, true) ? $domain : '';
+    }
+
+    /**
+     * Check if domain is a managed domain
+     *
+     * @param string $domain
+     * @return bool
+     */
+    public static function isManagedDomain($domain)
+    {
+        return in_array($domain, self::getManagedDomains(), true);
     }
 }

--- a/src/plib/library/Settings.php
+++ b/src/plib/library/Settings.php
@@ -1,0 +1,60 @@
+<?php
+// Copyright 1999-2018. Plesk International GmbH.
+
+/**
+ * Class Settings
+ *
+ * Wrapper Class for Plesk Settings
+ */
+class Modules_Route53_Settings
+{
+    /**
+     * Returns managedDomains from Plesk Settings
+     *
+     * @return array
+     */
+    public static function getManagedDomains()
+    {
+        $managedDomains = [];
+
+        if ($managedDomainsSetting = pm_Settings::get('managedDomains')) {
+            $managedDomains = explode(',', $managedDomainsSetting);
+        }
+
+        return $managedDomains;
+    }
+
+    /**
+     * Sets managedDomains in Plesk settings
+     *
+     * @param array $managedDomains
+     */
+    public static function setManagedDomains($managedDomains)
+    {
+        pm_Settings::set('managedDomains', implode(',', $managedDomains));
+    }
+
+    /**
+     * Adds managed domain to managedDomains in Plesk Settings
+     *
+     * @param string $managedDomain
+     */
+    public static function addManagedDomain($managedDomain)
+    {
+        $managedDomains = self::getManagedDomains();
+        $managedDomains[] = $managedDomain;
+        self::setManagedDomains($managedDomains);
+    }
+
+    /**
+     * Remove managedDomain from managedDomains in Plesk Settings
+     *
+     * @param int $id
+     */
+    public static function removeManagedDomainById($id)
+    {
+        $managedDomains = self::getManagedDomains();
+        unset($managedDomains[$id]);
+        self::setManagedDomains($managedDomains);
+    }
+}

--- a/src/plib/library/Settings.php
+++ b/src/plib/library/Settings.php
@@ -8,7 +8,7 @@
  */
 class Modules_Route53_Settings
 {
-    const MANAGE_DOMAIN_MODE_A_RECORD_WITH_SERVER_ADDRESS = 'ARecordWithServerAddress';
+    const MANAGED_DOMAIN_WITHOUT_NS = 'ManagedDomainWithoutNs';
 
     /**
      * Returns managedDomains from Plesk Settings
@@ -42,7 +42,7 @@ class Modules_Route53_Settings
      * @param string $managedDomain
      * @param string $mode
      */
-    public static function addManagedDomain($managedDomain, $mode = self::MANAGE_DOMAIN_MODE_A_RECORD_WITH_SERVER_ADDRESS)
+    public static function addManagedDomain($managedDomain, $mode = self::MANAGED_DOMAIN_WITHOUT_NS)
     {
         $managedDomains = self::getManagedDomains();
         $managedDomain = strtolower($managedDomain);

--- a/src/plib/resources/locales/en-US.php
+++ b/src/plib/resources/locales/en-US.php
@@ -58,4 +58,11 @@ $messages = array(
     'cliClearSuccess' => 'Authentication token was cleared.',
     'cliValidationFailed' => 'Validation failed.',
     'login' => 'Log in',
+    'managedDomainsTitle' => 'Managed Domains',
+    'managedDomainColumn' => 'Managed Domain',
+    'managedDomainLabel' => 'Managed Domain',
+    'createManagedDomainButton' => 'Create Managed Domain',
+    'createManagedDomainHint' => 'Create Managed Domain to handle Subdomains not registered in Plesk',
+    'deleteManagedDomainButton' => 'Delete Managed Domain',
+    'managedDomainCreated' => 'Managed Domain created',
 );

--- a/src/plib/resources/locales/en-US.php
+++ b/src/plib/resources/locales/en-US.php
@@ -64,5 +64,8 @@ $messages = array(
     'createManagedDomainButton' => 'Create Managed Domain',
     'createManagedDomainHint' => 'Create Managed Domain to handle Subdomains not registered in Plesk',
     'deleteManagedDomainButton' => 'Delete Managed Domain',
+    'managedDomainModeLabel' => 'Mode',
     'managedDomainCreated' => 'Managed Domain created',
+    'modeColumn' => 'Mode',
+    'managedDomainsModeARecordWithServerAddress' => 'A-Record with Server Address',
 );

--- a/src/plib/resources/locales/en-US.php
+++ b/src/plib/resources/locales/en-US.php
@@ -67,5 +67,5 @@ $messages = array(
     'managedDomainModeLabel' => 'Mode',
     'managedDomainCreated' => 'Managed Domain created',
     'modeColumn' => 'Mode',
-    'managedDomainsModeARecordWithServerAddress' => 'A-Record with Server Address',
+    'managedDomainsModeManagedDomainWithoutNs' => 'Write records to parent zone',
 );

--- a/src/plib/resources/locales/en-US.php
+++ b/src/plib/resources/locales/en-US.php
@@ -68,4 +68,5 @@ $messages = array(
     'managedDomainCreated' => 'Managed Domain created',
     'modeColumn' => 'Mode',
     'managedDomainsModeManagedDomainWithoutNs' => 'Write records to parent zone',
+    'regionLabel' => 'AWS Region'
 );

--- a/src/plib/scripts/post-install.php
+++ b/src/plib/scripts/post-install.php
@@ -9,6 +9,11 @@ if (empty($keyType) && !empty($key)) {
     pm_Settings::set('keyType', Modules_Route53_Form_Settings::KEY_TYPE_USER_CREDENTAL);
 }
 
+if (empty(pm_Settings::get('region'))) {
+    // set us-east-1 as default to prevent post-install failure
+    pm_Settings::set('region', 'us-east-1');
+}
+
 try {
     if (substr(PHP_OS, 0, 3) == 'WIN') {
         $cmd = '"' . PRODUCT_ROOT . '\bin\extension.exe"';

--- a/src/plib/scripts/route53.php
+++ b/src/plib/scripts/route53.php
@@ -301,8 +301,10 @@ function getIpAddresses()
     $addressInfos = $ipResponse->xpath('/packet/ip/get/result/addresses/ip_info');
 
     foreach ($addressInfos as $addressInfo) {
-        $address = (string)$addressInfo->ip_address;
-        $addresses[$address] = strpos($address, '.') ? 'A' : 'AAAA';
+        $address = (string)$addressInfo->public_ip_address;
+        if ($address) {
+            $addresses[$address] = strpos($address, '.') ? 'A' : 'AAAA';
+        }
     }
 
     return $addresses;

--- a/src/plib/views/scripts/index/create-managed-domain.phtml
+++ b/src/plib/views/scripts/index/create-managed-domain.phtml
@@ -1,0 +1,4 @@
+<?php
+// Copyright 1999-2018. Plesk International GmbH.
+?>
+<?php echo $this->form ?>

--- a/src/plib/views/scripts/index/managed-domain.phtml
+++ b/src/plib/views/scripts/index/managed-domain.phtml
@@ -1,0 +1,5 @@
+<?php
+// Copyright 1999-2018. Plesk International GmbH.
+?>
+<?php if ($this->tabs) echo $this->renderTabs($this->tabs) ?>
+<?php echo $this->renderList($this->list) ?>


### PR DESCRIPTION
This feature enables to register domains in the extension, that are not managed by plesk. This basically allows to create subdomain for a domain, that is not registered as domain. Currently adding a subdomain when a hosted zone for the parent domain exists, results in an error because both share the same delegation set.

E.g. You want to have a free subdomain for your customers "abc.xyz" which is registered in Route53. Because you can't share a domain for multiple customers, a customer would have to create a this subdomain as Domain "etc.abc.xyz". With this feature it's now possible to handle these domains.

Currently all Records of a Subdomain are added to the hosted zone of the parent domain. This could be extended to support creating a new hosted zone for each subdomain and register the Nameservers of the subdomain to the parent hosted zone (explained here https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/dns-routing-traffic-for-subdomains.html#dns-routing-traffic-for-subdomains-new-hosted-zone).

I also made sure, that the parent domain record is not deleted if "Remove all Zones"-Button is used. Moreover I changed the way how records are updated. Instead of deleting them, the current records are fetched from the hosted zone and before commit compared to the changed being made. This resolves issues with having the same zone used by multiple plesk servers.