### PR TITLE
EXTPLESK-9087 Hide the contents of the secret key field

### DIFF
--- a/src/plib/library/Form/Element/StyledPassword.php
+++ b/src/plib/library/Form/Element/StyledPassword.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * Form password input element with additional CSS-style
+ */
+class Modules_Route53_Form_Element_StyledPassword extends AdminPanel_Form_Element_Password
+{
+    public function init()
+    {
+        $cssClassesOrig = $this->getAttrib('class');
+        parent::init();
+        $cssClassesNew = $this->getAttrib('class');
+        if (!empty($cssClassesOrig) && strpos($cssClassesNew, $cssClassesOrig) === false) {
+            $this->setAttrib('class', "{$cssClassesOrig} {$cssClassesNew}");
+        }
+    }
+}

--- a/src/plib/library/Form/Settings.php
+++ b/src/plib/library/Form/Settings.php
@@ -18,7 +18,7 @@ class Modules_Route53_Form_Settings extends pm_Form_Simple
         if (!empty($options['isConsole'])) {
             $this->isConsole = $options['isConsole'];
         }
-
+        $this->addPrefixPath('Modules_Route53_Form_Element_', __DIR__ . '/Element/', static::ELEMENT);
         parent::__construct($options);
     }
 
@@ -38,11 +38,12 @@ class Modules_Route53_Form_Settings extends pm_Form_Simple
                 array('NotEmpty', true),
             ),
         ));
-        $this->addElement('text', 'secret', array(
+        $this->addElement('StyledPassword', 'secret', array(
             'label' => pm_Locale::lmsg('secretLabel'),
             'value' => pm_Settings::get('secret'),
             'class' => 'f-large-size',
             'required' => true,
+            'renderPassword' => true,
             'validators' => array(
                 array('NotEmpty', true),
             ),


### PR DESCRIPTION
### Before
<img width="690" height="121" alt="image" src="https://github.com/user-attachments/assets/95bf1169-4952-4649-9b9b-e3d4ff825a27" />

### After
<img width="712" height="114" alt="image" src="https://github.com/user-attachments/assets/02f66b49-c475-48d5-9e1f-34973e91809d" />
