### PR TITLE
Bugfix/extplesk 9087 visible credentials in amazon route 53 extension

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+# 2.9.10 (8 Oct 2025)
+
+* [-] Fixed the issue where the data in the "Secret" on the extension's page in Plesk was not masked. (EXTPLESK-9087)
+
 # 2.9.9 (22 May 2025)
 
 * [*] Added support for PHP 8.4 to ensure compatibility with future Plesk releases.

--- a/src/meta.xml
+++ b/src/meta.xml
@@ -6,7 +6,7 @@
   <description>This extension provides the functionality needed for integration with Amazon Route 53. It is a highly available and scalable Domain Name System (DNS) web service.</description>
   <category>dns</category>
   <category>clouds</category>
-  <version>2.9.9</version>
+  <version>2.9.10</version>
   <release>{{RELEASE}}</release>
   <vendor>Plesk</vendor>
   <url>https://github.com/plesk/ext-route53</url>

--- a/src/plib/library/Form/Element/StyledPassword.php
+++ b/src/plib/library/Form/Element/StyledPassword.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * Form password input element with additional CSS-style
+ */
+class Modules_Route53_Form_Element_StyledPassword extends AdminPanel_Form_Element_Password
+{
+    public function init()
+    {
+        $cssClassesOrig = $this->getAttrib('class');
+        parent::init();
+        $cssClassesNew = $this->getAttrib('class');
+        if (!empty($cssClassesOrig) && strpos($cssClassesNew, $cssClassesOrig) === false) {
+            $this->setAttrib('class', "{$cssClassesOrig} {$cssClassesNew}");
+        }
+    }
+}

--- a/src/plib/library/Form/Settings.php
+++ b/src/plib/library/Form/Settings.php
@@ -18,7 +18,7 @@ class Modules_Route53_Form_Settings extends pm_Form_Simple
         if (!empty($options['isConsole'])) {
             $this->isConsole = $options['isConsole'];
         }
-
+        $this->addPrefixPath('Modules_Route53_Form_Element_', __DIR__ . '/Element/', static::ELEMENT);
         parent::__construct($options);
     }
 
@@ -38,11 +38,12 @@ class Modules_Route53_Form_Settings extends pm_Form_Simple
                 array('NotEmpty', true),
             ),
         ));
-        $this->addElement('text', 'secret', array(
+        $this->addElement('StyledPassword', 'secret', array(
             'label' => pm_Locale::lmsg('secretLabel'),
             'value' => pm_Settings::get('secret'),
             'class' => 'f-large-size',
             'required' => true,
+            'renderPassword' => true,
             'validators' => array(
                 array('NotEmpty', true),
             ),


### PR DESCRIPTION
### Before
<img width="709" height="117" alt="image" src="https://github.com/user-attachments/assets/df7bdc71-4491-4293-90ee-4b659f370301" />

### After
<img width="721" height="103" alt="image" src="https://github.com/user-attachments/assets/eb61e594-09fb-432b-a548-9b865652e694" />
